### PR TITLE
Github version bumping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+
+cache/

--- a/README.md
+++ b/README.md
@@ -37,10 +37,19 @@ Lita has great documentation. Read [this](http://docs.lita.io/plugin-authoring/)
   1. Install [ngrok](https://ngrok.com/download).
   2. Launch ngrok inside the lita dev VM.
     * `./ngrok http 8080`
+  3. Follow instructions [here](https://dashboard.ngrok.com/get-started) to setup ngrok.
 3. Add a webhook to your github repo per instructions [here](https://developer.github.com/guides/delivering-deployments/).
   * You can find the ngrok url to use at [ngrok dashboard](https://dashboard.ngrok.com/status).
-4. Run lita within the lita development environment:
+4. Copy the github key you would like to use into `/home/lita/.ssh/github` with mod `0600`.
+5. Create `/home/lita/.ssh/config` to use the correct key when talking to Github:
+  ```
+  Host github.com
+  IdentityFile /home/lita/.ssh/github
+  StrictHostKeyChecking no
+  ```
+6. Run lita within the lita development environment:
   * `bundle exec lita` from your lita dev VM.
+
 
 ## Questions
 

--- a/lib/lita/project_repo.rb
+++ b/lib/lita/project_repo.rb
@@ -11,9 +11,9 @@ module Lita
     attr_reader :github_url
     attr_reader :version_bump_command
 
-    def initialize(github_url, version_bump_command = nil)
-      @github_url = github_url
-      @version_bump_command = version_bump_command
+    def initialize(project)
+      @github_url = project[:github_url]
+      @version_bump_command = project[:version_bump_command]
 
       Dir.mkdir(CACHE_DIRECTORY) unless File.exist? CACHE_DIRECTORY
     end
@@ -24,10 +24,12 @@ module Lita
       Bundler.with_clean_env do
         run_command(version_bump_command)
       end
+    end
 
-      if !run_command("git config -l").stdout.match /lita-versioner@chef.io/
-        run_command("git config user.email \"lita-versioner@chef.io\"")
-        run_command("git config user.name \"Lita Versioner\"")
+    def tag_and_commit
+      if !run_command("git config -l").stdout.match /chef-versioner@chef.io/
+        run_command("git config user.email \"chef-versioner@chef.io\"")
+        run_command("git config user.name \"Chef Versioner\"")
       end
 
       run_command("git add -A")
@@ -46,6 +48,7 @@ module Lita
     end
 
     def run_command(command, cwd: repo_directory)
+      Lita.logger.info("Running command: '#{command}'")
       shellout = Mixlib::ShellOut.new(
         command,
         cwd: cwd,

--- a/lib/lita/project_repo.rb
+++ b/lib/lita/project_repo.rb
@@ -1,0 +1,55 @@
+require "mixlib/shellout"
+require "json"
+require "uri"
+
+module Lita
+  class ProjectRepo
+    class CommandError < StandardError; end
+
+    CACHE_DIRECTORY = "./cache"
+
+    attr_reader :github_url
+
+    def initialize(github_url)
+      @github_url = github_url
+
+      Dir.mkdir(CACHE_DIRECTORY) unless File.exist? CACHE_DIRECTORY
+    end
+
+    # Clones the repo into cache or refreshes the repo in cache.
+    def refresh
+      if Dir.exists? repo_directory
+        run_command("git reset --hard origin/master")
+        run_command("git clean -fdx")
+      else
+        run_command("git clone #{github_url}", cwd: File.dirname(repo_directory))
+      end
+    end
+
+    def run_command(command, cwd: repo_directory)
+      shellout = Mixlib::ShellOut.new(
+        command,
+        cwd: cwd,
+        timeout: 3600
+      )
+      shellout.run_command
+
+      raise CommandError, [
+        "Error running git command #{command}:",
+        "stdout: #{shellout.stdout}",
+        "stderr: #{shellout.stderr}"
+      ].join("\n") if shellout.error?
+    end
+
+    def repo_directory
+      File.join(CACHE_DIRECTORY, repo_name)
+    end
+
+    def repo_name
+      # Note that this matches github urls both like:
+      #   https://github.com/litaio/development-environment.git
+      #   git@github.com:chef-cookbooks/languages.git
+      github_url.match(/.*\/(.*)\.git$/)[1]
+    end
+  end
+end

--- a/lita-versioner.gemspec
+++ b/lita-versioner.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "lita", ">= 4.4"
+  spec.add_runtime_dependency "mixlib-shellout"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry-byebug"

--- a/spec/lita/handlers/versioner_spec.rb
+++ b/spec/lita/handlers/versioner_spec.rb
@@ -24,14 +24,14 @@ describe Lita::Handlers::Versioner, lita_handler: true do
   it "builds with master by default" do
     # lita-rspec is doing something with subject therefore we need expect_any_instance_of here.
     expect_any_instance_of(Lita::Handlers::Versioner).to receive(:trigger_build)
-      .with("harmony-trigger-ad_hoc", "master").and_return(true)
+      .with("master").and_return(true)
     send_command("build harmony")
   end
 
   it "builds with the specified tag" do
     # lita-rspec is doing something with subject therefore we need expect_any_instance_of here.
     expect_any_instance_of(Lita::Handlers::Versioner).to receive(:trigger_build)
-      .with("harmony-trigger-ad_hoc", "example").and_return(true)
+      .with("example").and_return(true)
     send_command("build harmony example")
   end
 
@@ -46,7 +46,7 @@ describe Lita::Handlers::Versioner, lita_handler: true do
         req.headers["X-GitHub-Event"] = event_type
         req.params[:payload] = {
           repository: {
-            name: repository
+            full_name: "chef/#{repository}"
           },
           action: pull_request_action,
           pull_request: {

--- a/spec/lita/handlers/versioner_spec.rb
+++ b/spec/lita/handlers/versioner_spec.rb
@@ -96,6 +96,7 @@ describe Lita::Handlers::Versioner, lita_handler: true do
       let(:pull_request_merged) { true }
 
       it "skips build" do
+        expect_any_instance_of(Lita::Handlers::Versioner).to receive(:bump_version_in_git)
         expect_any_instance_of(Lita::Handlers::Versioner).to receive(:trigger_build)
         generate_github_event
       end

--- a/spec/lita/project_repo_spec.rb
+++ b/spec/lita/project_repo_spec.rb
@@ -9,10 +9,12 @@ describe Lita::ProjectRepo do
   let(:project_name) { "lita-versioner" }
   let(:project_url) { "https://github.com/chef/#{project_name}.git" }
   let(:version_bump_cmd) { nil }
+  let(:version_show_cmd) { nil }
   let(:project_repo) {
     Lita::ProjectRepo.new({
       github_url: project_url,
-      version_bump_command: version_bump_cmd
+      version_bump_command: version_bump_cmd,
+      version_show_command: version_show_cmd
     })
   }
 
@@ -53,13 +55,14 @@ describe Lita::ProjectRepo do
 
   context "with setup to bump the version" do
     let(:version_bump_cmd) { "echo 1.1.1 > VERSION" }
+    let(:version_show_cmd) { "echo 1.1.1" }
     let(:version_file) { File.join(project_repo.repo_directory, "VERSION") }
     before do
       original_run_command = project_repo.method(:run_command)
       allow(project_repo).to receive(:run_command) do |command|
         # Do not push the branch for real. But run a status command to be able
         # correctly return a Shellout object.
-        if command == "git push origin master"
+        if command == "git push origin master --tags"
           command = "git status"
         end
         original_run_command.call(command)
@@ -78,6 +81,7 @@ describe Lita::ProjectRepo do
       project_repo.tag_and_commit
       expect(File.read(version_file)).to match /1.1.1/
       expect(project_repo.run_command("git log").stdout).to match /Automatic version bump for lita-versioner by lita-versioner./
+      expect(project_repo.run_command("git describe --tags").stdout.chomp).to eq("v1.1.1")
     end
   end
 

--- a/spec/lita/project_repo_spec.rb
+++ b/spec/lita/project_repo_spec.rb
@@ -9,7 +9,12 @@ describe Lita::ProjectRepo do
   let(:project_name) { "lita-versioner" }
   let(:project_url) { "https://github.com/chef/#{project_name}.git" }
   let(:version_bump_cmd) { nil }
-  let(:project_repo) { Lita::ProjectRepo.new(project_url, version_bump_cmd) }
+  let(:project_repo) {
+    Lita::ProjectRepo.new({
+      github_url: project_url,
+      version_bump_command: version_bump_cmd
+    })
+  }
 
   before do
     @current_pwd = Dir.pwd
@@ -70,6 +75,7 @@ describe Lita::ProjectRepo do
 
     it "can bump the version" do
       project_repo.bump_version
+      project_repo.tag_and_commit
       expect(File.read(version_file)).to match /1.1.1/
       expect(project_repo.run_command("git log").stdout).to match /Automatic version bump for lita-versioner by lita-versioner./
     end

--- a/spec/lita/project_repo_spec.rb
+++ b/spec/lita/project_repo_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+require "lita/project_repo"
+
+describe Lita::ProjectRepo do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:project_name) { "lita-versioner" }
+  let(:project_url) { "https://github.com/chef/#{project_name}.git" }
+  let(:project_repo) { Lita::ProjectRepo.new(project_url) }
+
+  before do
+    @current_pwd = Dir.pwd
+    Dir.chdir(tmpdir)
+  end
+
+  after do
+    Dir.chdir(@current_pwd)
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  it "can clone the repo" do
+    project_repo.refresh
+    expect(Dir.exists?(project_repo.repo_directory)).to be true
+    expect(Dir["#{project_repo.repo_directory}/**/*"].length).to be > 5
+  end
+
+  context "with an existing repo" do
+    before do
+      project_repo.refresh
+      files = Dir["#{project_repo.repo_directory}/**/*"]
+      @file_count = files.length
+
+      # Delete some files
+      files.first(5).each do |p|
+        FileUtils.rm_rf(p)
+      end
+    end
+
+    it "can update the repo" do
+      project_repo.refresh
+      expect(Dir.exists?(project_repo.repo_directory)).to be true
+      expect(Dir["#{project_repo.repo_directory}/**/*"].length).to eq(@file_count)
+    end
+  end
+end

--- a/spec/lita/project_repo_spec.rb
+++ b/spec/lita/project_repo_spec.rb
@@ -8,7 +8,8 @@ describe Lita::ProjectRepo do
   let(:tmpdir) { Dir.mktmpdir }
   let(:project_name) { "lita-versioner" }
   let(:project_url) { "https://github.com/chef/#{project_name}.git" }
-  let(:project_repo) { Lita::ProjectRepo.new(project_url) }
+  let(:version_bump_cmd) { nil }
+  let(:project_repo) { Lita::ProjectRepo.new(project_url, version_bump_cmd) }
 
   before do
     @current_pwd = Dir.pwd
@@ -44,4 +45,34 @@ describe Lita::ProjectRepo do
       expect(Dir["#{project_repo.repo_directory}/**/*"].length).to eq(@file_count)
     end
   end
+
+  context "with setup to bump the version" do
+    let(:version_bump_cmd) { "echo 1.1.1 > VERSION" }
+    let(:version_file) { File.join(project_repo.repo_directory, "VERSION") }
+    before do
+      original_run_command = project_repo.method(:run_command)
+      allow(project_repo).to receive(:run_command) do |command|
+        # Do not push the branch for real. But run a status command to be able
+        # correctly return a Shellout object.
+        if command == "git push origin master"
+          command = "git status"
+        end
+        original_run_command.call(command)
+      end
+
+      Dir.mkdir(project_repo.repo_directory)
+      FileUtils.touch(version_file)
+      File.open(version_file, "w+") do |f|
+        f.puts "1.1.0"
+      end
+      project_repo.run_command("git init .")
+    end
+
+    it "can bump the version" do
+      project_repo.bump_version
+      expect(File.read(version_file)).to match /1.1.1/
+      expect(project_repo.run_command("git log").stdout).to match /Automatic version bump for lita-versioner by lita-versioner./
+    end
+  end
+
 end


### PR DESCRIPTION
/cc: @chef/engineering-services 

This PR adds the ability to bump the version in the watched github repository. Here is an example log output from creating a PR and merging it. The lines without timestamp start will actually appear in the Chat application lita is connected to.

```
[2016-03-02 00:45:27 UTC] INFO: Processing 'create' event for 'chef/lita-test'.
[2016-03-02 00:45:27 UTC] INFO: Informing 'engineering-services' with: 'Skipping event 'create' for 'chef/lita-test''
Skipping event 'create' for 'chef/lita-test'
[2016-03-02 00:45:27 UTC] INFO: Processing 'push' event for 'chef/lita-test'.
[2016-03-02 00:45:27 UTC] INFO: Informing 'engineering-services' with: 'Skipping event 'push' for 'chef/lita-test''
Skipping event 'push' for 'chef/lita-test'
[2016-03-02 00:45:27 UTC] INFO: Processing 'pull_request' event for 'chef/lita-test'.
[2016-03-02 00:45:27 UTC] INFO: Informing 'engineering-services' with: 'Looks like 'https://api.github.com/repos/chef/lita-test/pulls/13' is not merged with commits. Skipping.'
Looks like 'https://api.github.com/repos/chef/lita-test/pulls/13' is not merged with commits. Skipping.
[2016-03-02 00:45:46 UTC] INFO: Processing 'pull_request' event for 'chef/lita-test'.
[2016-03-02 00:45:46 UTC] INFO: Running command: 'git fetch origin'
[2016-03-02 00:45:47 UTC] INFO: Processing 'push' event for 'chef/lita-test'.
[2016-03-02 00:45:47 UTC] INFO: Informing 'engineering-services' with: 'Skipping event 'push' for 'chef/lita-test''
Skipping event 'push' for 'chef/lita-test'
[2016-03-02 00:45:48 UTC] INFO: Running command: 'git reset --hard origin/master'
[2016-03-02 00:45:48 UTC] INFO: Running command: 'git clean -fdx'
[2016-03-02 00:45:48 UTC] INFO: Running command: 'bundle install && bundle exec rake version:bump_patch'
[2016-03-02 00:45:49 UTC] INFO: Running command: 'bundle exec rake version:show'
[2016-03-02 00:45:49 UTC] INFO: Running command: 'git config -l'
[2016-03-02 00:45:49 UTC] INFO: Running command: 'git add -A'
[2016-03-02 00:45:49 UTC] INFO: Running command: 'git commit -m "Bump version of lita-test to 1.0.11 by Chef Versioner."'
[2016-03-02 00:45:49 UTC] INFO: Running command: 'git tag -a v1.0.11 -m "Version tag for 1.0.11."'
[2016-03-02 00:45:49 UTC] INFO: Running command: 'git push origin master --tags'
[2016-03-02 00:45:51 UTC] INFO: Running command: 'bundle exec rake version:show'
[2016-03-02 00:45:51 UTC] INFO: Kicking off a build for harmony-trigger-ad_hoc with v1.0.11.
[2016-03-02 00:45:51 UTC] INFO: Informing 'engineering-services' with: 'Kicked off a build for 'harmony-trigger-ad_hoc' with tag 'v1.0.11'.'
Kicked off a build for 'harmony-trigger-ad_hoc' with tag 'v1.0.11'.
[2016-03-02 00:45:52 UTC] INFO: Processing 'create' event for 'chef/lita-test'.
[2016-03-02 00:45:52 UTC] INFO: Informing 'engineering-services' with: 'Skipping event 'create' for 'chef/lita-test''
Skipping event 'create' for 'chef/lita-test'
[2016-03-02 00:45:52 UTC] INFO: Processing 'push' event for 'chef/lita-test'.
[2016-03-02 00:45:52 UTC] INFO: Informing 'engineering-services' with: 'Skipping event 'push' for 'chef/lita-test''
Skipping event 'push' for 'chef/lita-test'
[2016-03-02 00:45:52 UTC] INFO: Processing 'push' event for 'chef/lita-test'.
[2016-03-02 00:45:52 UTC] INFO: Informing 'engineering-services' with: 'Skipping event 'push' for 'chef/lita-test''
Skipping event 'push' for 'chef/lita-test'
```