### PR TITLE
Cleanup local tags if push fails. Convert the noisy inform to log.

### DIFF
--- a/lib/lita/handlers/versioner.rb
+++ b/lib/lita/handlers/versioner.rb
@@ -109,14 +109,19 @@ module Lita
         when "pull_request"
           # https://developer.github.com/v3/activity/events/types/#pullrequestevent
           # If the pull request is merged with some commits
-          if payload["action"] == "closed" && payload["pull_request"]["merged"]
-            new_version = bump_version_in_git
-            trigger_build("v#{new_version}")
+          if payload["action"] == "closed"
+            if payload["pull_request"]["merged"]
+              inform("'#{payload["pull_request"]["html_url"]}' is just merged. Working on it...")
+              new_version = bump_version_in_git
+              trigger_build("v#{new_version}")
+            else
+              inform("Skipping: '#{payload["pull_request"]["html_url"]}'. It was closed without merging any commits.")
+            end
           else
-            inform("Looks like '#{payload["pull_request"]["url"]}' is not merged with commits. Skipping.")
+            log("Skipping: '#{payload["pull_request"]["html_url"]}' Action: '#{payload["action"]}' Merged? '#{payload["pull_request"]["merged"]}'")
           end
         else
-          inform("Skipping event '#{event_type}' for '#{repository}'")
+          inform("Skipping event '#{event_type}' for '#{repository}'. I am only handling 'pull_request' events.")
         end
       end
 

--- a/lib/lita/project_repo.rb
+++ b/lib/lita/project_repo.rb
@@ -47,7 +47,13 @@ module Lita
       run_command("git add -A")
       run_command("git commit -m \"Bump version of #{repo_name} to #{version} by Chef Versioner.\"")
       run_command("git tag -a v#{version} -m \"Version tag for #{version}.\"")
-      run_command("git push origin master --tags")
+      begin
+        run_command("git push origin master --tags")
+      rescue CommandError => e
+        # We need to cleanup the local tag we have created if the push has failed.
+        run_command("git tag -d v#{version}")
+        raise e
+      end
     end
 
     # Clones the repo into cache or refreshes the repo in cache.


### PR DESCRIPTION
* Fixes https://github.com/chef/lita-versioner/issues/8
* Does not inform for `Looks like 'https://api.github.com/repos/chef/chef/pulls/4751' is not merged with commits. Skipping.` kind of messages. 

/cc: @jkeiser @chef/engineering-services 