### PR TITLE
Move notifications and add compare link to dep builds

### DIFF
--- a/lib/lita/handlers/dependency_updater.rb
+++ b/lib/lita/handlers/dependency_updater.rb
@@ -37,7 +37,7 @@ module Lita
           version_bump_command: "bundle install && bundle exec rake version:bump",
           version_show_command: "bundle exec rake version:show",
           dependency_update_command: "bundle install && bundle exec rake dependencies",
-          inform_channel: "ship-it"
+          inform_channel: "workflow-pool"
         }
       }
 

--- a/lib/lita/handlers/dependency_updater.rb
+++ b/lib/lita/handlers/dependency_updater.rb
@@ -104,7 +104,8 @@ module Lita
         dependencies_updated, reason = dep_builder.run
         if dependencies_updated
           trigger_jenkins_job(pipeline_name)
-          inform("Started dependency update build for project #{pipeline_name}", project_info)
+          msg = "Started dependency update build for project #{pipeline_name}. Diff: https://github.com/chef/chef-dk/compare/auto_dependency_bump_test"
+          inform(msg, project_info)
           [true, "build started"]
         else
           [false, reason]

--- a/lib/lita/handlers/versioner.rb
+++ b/lib/lita/handlers/versioner.rb
@@ -37,14 +37,14 @@ module Lita
           github_url: "git@github.com:chef/chef.git",
           version_bump_command: "bundle install && bundle exec rake version:bump",
           version_show_command: "bundle exec rake version:show",
-          inform_channel: "ship-it"
+          inform_channel: "workflow-pool"
         },
         chefdk: {
           pipeline: "chefdk-trigger-release",
           github_url: "git@github.com:chef/chef-dk.git",
           version_bump_command: "bundle install && bundle exec rake version:bump",
           version_show_command: "bundle exec rake version:show",
-          inform_channel: "ship-it"
+          inform_channel: "workflow-pool"
         }
       }
 


### PR DESCRIPTION
Moves notifications into #workflow-pool (so we can archive #ship-it). Also, add a link to GH compare view for the dependency update changes