### PR TITLE
Don't recursively make handlers

### DIFF
--- a/lib/lita/handlers/bumpbot_handler.rb
+++ b/lib/lita/handlers/bumpbot_handler.rb
@@ -73,29 +73,6 @@ module Lita
       end
 
       #
-      # Create a new handler which will send messages and HTTP responses to the
-      # same place as the original.
-      #
-      # Versioner.from_handler(handler) will create a Versioner object;
-      # DependencyUpdater.from_handler(handler) will create a DependencyUpdater
-      # object; etc. etc.
-      #
-      def self.from_handler(handler)
-        result = new(handler.robot)
-        result.inherit_handler(handler)
-        result
-      end
-
-      #
-      # Inherit response and output information from another handler (see `from_handler`)
-      #
-      def inherit_handler(handler)
-        @project_name = handler.project_name
-        @response = handler.response
-        output.inherit_output(handler.output)
-      end
-
-      #
       # Ensure all subclasses are in the Lita versioner namespace so they share config.
       #
       def self.inherited(klass)
@@ -196,7 +173,7 @@ module Lita
         create_sandbox_directory
         debug("Started #{title}")
 
-        # Actually handler the command
+        # Actually handle the command
         instance_eval(&block)
 
         end_time = Time.now.utc

--- a/lib/lita/handlers/versioner.rb
+++ b/lib/lita/handlers/versioner.rb
@@ -52,13 +52,10 @@ module Lita
       def github_handler(request, response)
         output.http_response = response
         # Filter out events and parse the response
-        handle "received github event #{request.params["payload"]}" do
+        handle "received github event" do
           pull_request_url, merge_commit_sha = parse_github_event(request)
           if pull_request_url
-            versioner = Versioner.from_handler(self)
-            versioner.handle "github merged pull request #{pull_request_url} for #{project_name}: #{merge_commit_sha}" do
-              bump_version_and_trigger_build
-            end
+            bump_version_and_trigger_build
           end
         end
       end
@@ -106,7 +103,7 @@ module Lita
           return
         end
 
-        info("'#{pull_request_url}' was just merged. Bumping version and submitting a build ...")
+        info("'#{pull_request_url}' was just merged at #{merge_commit_sha}. Bumping version and submitting a build ...")
 
         [ pull_request_url, merge_commit_sha ]
       end

--- a/lib/lita_versioner/handler_output.rb
+++ b/lib/lita_versioner/handler_output.rb
@@ -168,14 +168,6 @@ module LitaVersioner
       "`#{text.tr("`", "'")}`"
     end
 
-    # Output to the same place as another output object. Used by BumpbotHandler.from_handler
-    def inherit_output(other)
-      raise "Cannot inherit output of an unfinished handler!" if other.send(:progress_message_ts)
-      @lita_target = other.lita_target
-      @http_response = other.http_response
-      @status = other.status
-    end
-
     private
 
     attr_accessor :last_log_time


### PR DESCRIPTION
Turns out Lita makes a fresh handler for us for every request.

See https://github.com/litaio/lita/blob/master/lib/lita/http_callback.rb#L24
